### PR TITLE
Updated Tomcat to 9.0.98

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target/
 **/target/
+.vscode/

--- a/opensuse-tomcat-jre11-juli-image/src/main/docker/Dockerfile
+++ b/opensuse-tomcat-jre11-juli-image/src/main/docker/Dockerfile
@@ -27,13 +27,13 @@ ENV TOMCAT_ROOT_DIR $TOMCAT_PARENT_DIR/$TOMCAT_DIR_NAME
 ENV TOMCAT_CONF_DIR $TOMCAT_ROOT_DIR/conf
 
 # Download, extract Tomcat and remove unwanted web applications
-RUN curl -fsSL -o /wd/apache-tomcat-9.0.96.tar.gz https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.96/bin/apache-tomcat-9.0.96.tar.gz && \
-    echo ef3ac81debbc3a519c43d1fdb1c88ab26a8052af424d81bceccfbd6e663050a06d7aad7960fd5d11c17849829daebbebf33d92ac1158902283d0e534514aab93 \
-        /wd/apache-tomcat-9.0.96.tar.gz | sha512sum -c - && \
+RUN curl -fsSL -o /wd/apache-tomcat-9.0.98.tar.gz https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.98/bin/apache-tomcat-9.0.98.tar.gz && \
+    echo 07d87286e8ee84bb291069c596cf36233e56a14e3ecb6d65eea0fa7c7042ce5e75f5db31f210b96b6b25b80b34e626dd26c5a6ed5c052384a8587d62658b5e16 \
+        /wd/apache-tomcat-9.0.98.tar.gz | sha512sum -c - && \
     mkdir -p $TOMCAT_PARENT_DIR && \
     cd $TOMCAT_PARENT_DIR && \
-    tar xzf /wd/apache-tomcat-9.0.96.tar.gz && \
-    mv apache-tomcat-9.0.96 $TOMCAT_DIR_NAME && \
+    tar xzf /wd/apache-tomcat-9.0.98.tar.gz && \
+    mv apache-tomcat-9.0.98 $TOMCAT_DIR_NAME && \
     cd $TOMCAT_ROOT_DIR/webapps && \
     rm -rf docs/ examples/ host-manager/ manager/
 

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <dockerCafImagePrefix>${dockerImagePrefix}${dockerHubOrganization}${dockerOrgSeperator}</dockerCafImagePrefix>
         <dockerProjectVersion>${dockerVersionSeperator}${project.version}</dockerProjectVersion>
         <logbackVersion>1.2.3</logbackVersion>
-        <tomcatVersion>9.0.96</tomcatVersion>
+        <tomcatVersion>9.0.98</tomcatVersion>
         <projectDockerRegistry>opensuse-tomcat-jre11-image-${project.version}.project-registries.local</projectDockerRegistry>
     </properties>
 

--- a/release-notes-2.17.0.md
+++ b/release-notes-2.17.0.md
@@ -1,1 +1,10 @@
-404: Not Found
+!not-ready-for-release!
+
+#### Version Number
+${version-number}
+
+#### New Features
+
+- Update to Tomcat 9.0.98
+
+#### Known Issues


### PR DESCRIPTION
## Overview

This change mitigates a CVE found in Tomcat 9.0.96 by updating to 9.0.98.

## Reference links

- [CVE-2024-50379 - Red Hat Customer Portal](https://access.redhat.com/security/cve/CVE-2024-50379)
- [CVE-2024-56337 - Red Hat Customer Portal](https://access.redhat.com/security/cve/CVE-2024-56337)
- [CVE-2024-54677 - Red Hat Customer Portal](https://access.redhat.com/security/cve/CVE-2024-54677)
- [CVE-2024-52318 - Red Hat Customer Portal](https://access.redhat.com/security/cve/CVE-2024-52318)